### PR TITLE
Handle edge cases; insert global Org links; update doc strings

### DIFF
--- a/blk-pkg.el
+++ b/blk-pkg.el
@@ -1,4 +1,4 @@
 (define-package
     "blk"
-    "0.0.1"
-  "a package for making arbitrary links across text files")
+    "0.0.2"
+  "Rapidly create and follow links across text files")


### PR DESCRIPTION
Doc strings rewritten to normal Emacs standards.

`blk-run-grep-cmd' rewritten to not reallocate memory within loops.

Make `blk-insert' work in any major-mode by adding a default clause to `blk-insert-patterns' variable.